### PR TITLE
fix error with social icons where twitter and instagram were mixed up

### DIFF
--- a/layouts/partials/social-icons.html
+++ b/layouts/partials/social-icons.html
@@ -1,7 +1,7 @@
-{{ with .Site.Social.instagram -}}
+{{ with .Site.Social.twitter -}}
 <a class="py-2 px-2" href="https://twitter.com/{{ . }}"><i class="fab fa-twitter"></i></a>
 {{ end -}}
-{{ with .Site.Social.twitter -}}
+{{ with .Site.Social.instagram -}}
 <a class="py-2 px-2" href="https://instagram.com/{{ . }}"><i class="fab fa-instagram"></i></a>
 {{ end -}}
 {{ with .Site.Social.linkedin -}}


### PR DESCRIPTION
The twitter and instagram icon links were swapped.
Twitter variable was going in the instagram place and vice-versa.